### PR TITLE
User story #7 root url

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -25,7 +25,9 @@ from . import app
 def index():
     """ Root URL response """
     return (
-        "Reminder: return some useful information in json format about the service here",
+        # "Reminder: return some useful information in json format about the service here",
+        jsonify( Service = "products", Description = "represents the store items that the customer can buy", 
+        version = "1.0.0"),
         status.HTTP_200_OK,
     )
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -26,7 +26,7 @@ def index():
     """ Root URL response """
     return (
         # "Reminder: return some useful information in json format about the service here",
-        jsonify( name = "products", paths=url_for("index", _external=True),
+        jsonify( name = "Product REST API Service", paths=url_for("index", _external=True),
         version = "1.0"),
         status.HTTP_200_OK,
     )

--- a/service/routes.py
+++ b/service/routes.py
@@ -26,8 +26,8 @@ def index():
     """ Root URL response """
     return (
         # "Reminder: return some useful information in json format about the service here",
-        jsonify( Service = "products", Description = "represents the store items that the customer can buy", 
-        version = "1.0.0"),
+        jsonify( name = "products", paths=url_for("index", _external=True),
+        version = "1.0"),
         status.HTTP_200_OK,
     )
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -43,6 +43,7 @@ class TestYourResourceServer(TestCase):
     ######################################################################
 
     def test_index(self):
+        """It should call the Home Page"""
         resp = self.app.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -47,7 +47,7 @@ class TestYourResourceServer(TestCase):
         resp = self.app.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
-        self.assertEqual(data["name"], "products")
+        self.assertEqual(data["name"], "Product REST API Service")
         self.assertEqual(data["version"], "1.0")
         self.assertEqual(data["paths"], "http://localhost/products") #the test fails for now, because the url doesn't exist yet.
         

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -43,6 +43,10 @@ class TestYourResourceServer(TestCase):
     ######################################################################
 
     def test_index(self):
-        """ It should call the home page """
         resp = self.app.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["name"], "products")
+        self.assertEqual(data["version"], "1.0")
+        self.assertEqual(data["paths"], "http://localhost/products") #the test fails for now, because the url doesn't exist yet.
+        


### PR DESCRIPTION
  The root URL displays useful information about the service in JSON format. The tests for the homepage should pass when the URL "http://localhost/products" is created and the "paths" in the index function is changed from paths=url_for("index", _external=True) to paths=url_for("list_products", _external=True)