### PR TITLE
Add lint commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ install: ## Install dependencies
 	$(info Installing dependencies...)
 	sudo pip install -r requirements.txt
 
+lint: ## Run the linter
+	$(info Running linting...)
+	flake8 service --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 service --count --max-complexity=10 --max-line-length=127 --statistics
+
 test: ## Run the unit tests
 	$(info Running tests...)
 	nosetests --with-spec --spec-color


### PR DESCRIPTION
Can simply call make lint to check flake8 errors. 