### PR TITLE
Swaggerdoc

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -19,6 +19,7 @@ MAX_PRICE = 100.00
 MIN_RATE = 0
 MAX_RATE = 5
 MAX_DESCRIPTION_LENGTH = 63
+MAX_CATEGORY_LENGTH = 63
 logger = logging.getLogger("flask.app")
 
 # Create the SQLAlchemy object to be initialized later in init_db()
@@ -110,7 +111,7 @@ class Product(db.Model):
             else:
                 raise DataValidationError("Invalid range for [price]: " + str(price))
         else:
-            raise DataValidationError(
+            raise TypeError(
                 "Invalid type for float [price]: " + str(type(price))
             )
 
@@ -164,6 +165,9 @@ class Product(db.Model):
     def check_description(self, description):
         if not isinstance(description, str):
             raise TypeError
+        elif len(description) > MAX_DESCRIPTION_LENGTH:
+            raise DataValidationError(
+                "Description length over limit.")
         else:
             self.description = description
 
@@ -173,6 +177,9 @@ class Product(db.Model):
         elif category == "":
             raise DataValidationError(
                 "category field cannot be empty ")
+        elif len(category) > MAX_CATEGORY_LENGTH:
+            raise DataValidationError(
+                "Category length over limit ")
         else:
             self.category = category
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -12,12 +12,12 @@ Describe what your service does here
 from flask import request, abort  # url_for, jsonify
 from flask_restx import Resource, fields, reqparse, inputs  # Api,
 from service.utils import status  # HTTP Status Codes
-from service.models import Product, MIN_PRICE, MAX_PRICE, MAX_DESCRIPTION_LENGTH
+from service.models import Product
 
 # Import Flask application
 from . import app, api
 
-MAX_CATEGORY_LENGTH = 63
+
 ######################################################################
 # GET INDEX
 ######################################################################
@@ -131,7 +131,7 @@ class ProductResource(Resource):
     # ------------------------------------------------------------------
     # UPDATE AN EXISTING PRODUCT
     # ------------------------------------------------------------------
-    @api.doc('update_pets', security='apikey')
+    @api.doc('update_products', security='apikey')
     @api.response(404, 'Product not found')
     @api.response(400, 'The posted Product data was not valid')
     @api.expect(product_model)
@@ -151,7 +151,7 @@ class ProductResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 f"Product with id '{product_id}' was not found.",
             )
-        app.logger.info('Payload = %s ', api.payload)
+        app.logger.debug('Payload = %s ', api.payload)
         data = api.payload
         product.deserialize(data)
         product.id = product_id
@@ -162,7 +162,7 @@ class ProductResource(Resource):
     # ------------------------------------------------------------------
     # DELETE A PRODUCT
     # ------------------------------------------------------------------
-    @api.response(204, 'Pet deleted')
+    @api.response(204, 'Product deleted')
     def delete(self, product_id):
         """Delete a Product"""
         app.logger.info("Request to delete product with id: %s", product_id)
@@ -286,8 +286,8 @@ class ProductCollection(Resource):
         """
         app.logger.info("Request to create a product")
         check_content_type("application/json")
+        app.logger.debug('Payload = %s', api.payload)
         data = api.payload
-        app.logger.info("Post Args : %s ", data)
         data["rating"] = (
             None
             if "rating" not in data or data["rating"] is None
@@ -406,23 +406,14 @@ class PriceResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
-        app.logger.info('Payload = %s ', api.payload)
+        app.logger.debug('Payload = %s ', api.payload)
         new_price = api.payload
         if "price" not in new_price or new_price["price"] is None:
             abort(
                 status.HTTP_406_NOT_ACCEPTABLE,
                 description="Price should be in dict name 'price'.",
             )
-        if not isinstance(new_price["price"], float) and not isinstance(
-            new_price["price"], int
-        ):
-            abort(
-                status.HTTP_406_NOT_ACCEPTABLE,
-                description="Price should be of float or int datatype",
-            )
-        new_price["price"] = float(new_price["price"])
-        if new_price["price"] < MIN_PRICE or new_price["price"] > MAX_PRICE:
-            abort(status.HTTP_406_NOT_ACCEPTABLE, description="New price out of range.")
+        product.deserialize(new_price)
         product.price = new_price["price"]
         product.update()
         app.logger.info("Price of product with ID [%s] updated.", product.id)
@@ -456,12 +447,12 @@ class DescriptionResource(Resource):
         check_content_type("application/json")
         product = Product.find(product_id)
         if not product:
-            app.logger.info("Product_id not found.")
+            app.logger.debug("Product_id not found.")
             abort(
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
-        app.logger.info('Payload = %s ', api.payload)
+        app.logger.debug('Payload = %s ', api.payload)
         new_description = api.payload
         if (
             "description" not in new_description
@@ -471,16 +462,7 @@ class DescriptionResource(Resource):
                 status.HTTP_406_NOT_ACCEPTABLE,
                 description="Description should be in dict name 'description'.",
             )
-        if not isinstance(new_description["description"], str):
-            abort(
-                status.HTTP_406_NOT_ACCEPTABLE,
-                description="Description should be of str datatype",
-            )
-        if len(new_description["description"]) > MAX_DESCRIPTION_LENGTH:
-            abort(
-                status.HTTP_406_NOT_ACCEPTABLE,
-                description="Description length over limit.",
-            )
+        product.deserialize(new_description)
         product.description = new_description["description"]
         product.update()
         app.logger.info("Description of product with ID [%s] updated.", product.id)
@@ -519,26 +501,17 @@ class CategoryResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
-        app.logger.info('Payload = %s ', api.payload)
+        app.logger.debug('Payload = %s ', api.payload)
         new_category = api.payload
         if "category" not in new_category or new_category["category"] is None:
             abort(
                 status.HTTP_406_NOT_ACCEPTABLE,
                 description="Category should be in dict name 'category'.",
             )
-        if not isinstance(new_category["category"], str):
-            abort(
-                status.HTTP_406_NOT_ACCEPTABLE,
-                description="Category should be of str datatype",
-            )
-        if len(new_category["category"]) > MAX_CATEGORY_LENGTH:
-            abort(
-                status.HTTP_406_NOT_ACCEPTABLE,
-                description="Category length over limit.",
-            )
+        product.deserialize(new_category)
         product.category = new_category["category"]
         product.update()
-        app.logger.info("Description of product with ID [%s] updated.", product.id)
+        app.logger.info("Category of product with ID [%s] updated.", product.id)
         return product.serialize(), status.HTTP_200_OK
 
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -325,6 +325,8 @@ class RatingResource(Resource):
     @api.doc('Update The Rating')
     @api.response(404, 'Product not found')
     @api.response(406, 'JSON Not acceptable')
+    @api.expect(product_model)
+    @api.marshal_with(product_model)
     def put(self, product_id):
         """
         Updates the rating of a product on the basis of feedback provided.
@@ -342,6 +344,7 @@ class RatingResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
+        app.logger.info('Payload = %s ', api.payload)
         new_rating = api.payload
         if not isinstance(new_rating["rating"], int):
             abort(
@@ -384,6 +387,8 @@ class PriceResource(Resource):
     @api.doc('Update The Price')
     @api.response(404, 'Product not found')
     @api.response(406, 'JSON Format Not acceptable')
+    @api.expect(product_model)
+    @api.marshal_with(product_model)
     def put(self, product_id):
         """
         Updates the price of a product on the basis of feedback provided.
@@ -401,6 +406,7 @@ class PriceResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
+        app.logger.info('Payload = %s ', api.payload)
         new_price = api.payload
         if "price" not in new_price or new_price["price"] is None:
             abort(
@@ -436,6 +442,8 @@ class DescriptionResource(Resource):
     @api.doc('Update The Description')
     @api.response(404, 'Product not found')
     @api.response(406, 'JSON Format Not acceptable')
+    @api.expect(product_model)
+    @api.marshal_with(product_model)
     def put(self, product_id):
         """
         Updates the description of a product on the basis of feedback provided.
@@ -453,6 +461,7 @@ class DescriptionResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
+        app.logger.info('Payload = %s ', api.payload)
         new_description = api.payload
         if (
             "description" not in new_description
@@ -491,6 +500,8 @@ class CategoryResource(Resource):
     @api.doc('Update The Category')
     @api.response(404, 'Product not found')
     @api.response(406, 'JSON Format Not acceptable')
+    @api.expect(product_model)
+    @api.marshal_with(product_model)
     def put(self, product_id):
         """
         Updates the category of a product on the basis of feedback provided.
@@ -508,6 +519,7 @@ class CategoryResource(Resource):
                 status.HTTP_404_NOT_FOUND,
                 description=f"Product with id '{product_id}' was not found.",
             )
+        app.logger.info('Payload = %s ', api.payload)
         new_category = api.payload
         if "category" not in new_category or new_category["category"] is None:
             abort(

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -87,7 +87,7 @@
 
             <!-- RATING -->
             <div class="form-group">
-              <label class="control-label col-sm-2" for="product_rating.toFixed(2)">Rating:</label>
+              <label class="control-label col-sm-2" for="product_rating">Rating:</label>
               <div class="col-sm-10">
                 <input type="number" step="any" class="form-control" id="product_rating" placeholder="Enter rating for Product(Optional)">
               </div>
@@ -152,7 +152,7 @@
           <div class="form-horizontal">
             <!-- RATING -->
             <div class="form-group">
-              <label class="control-label col-sm-2" for="add_product_rating.toFixed(2)">Rating:</label>
+              <label class="control-label col-sm-2" for="add_product_rating">Rating:</label>
               <div class="col-sm-10">
                 <input type="number" step="1" class="form-control" id="add_product_rating" placeholder="Enter the rating you want to comment" required>
               </div>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -17,7 +17,7 @@ $(function () {
         $("#product_description").val(res.description);
         $("#product_available").val(res.available);
         $("#product_price").val(res.price);
-        $("#product_rating").val(res.rating);
+        $("#product_rating").val(res.rating.toFixed(2));
         $("#product_num_rating").val(res.no_of_users_rated);
     }
 

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -11,13 +11,19 @@ $(function () {
         }else{
             res.available = "False"
         }
+        if (res.rating != null){
+            product_rating = res.rating.toFixed(2)
+        }
+        else{
+            product_rating = null
+        }
         $("#product_id").val(res.id);
         $("#product_name").val(res.name);
         $("#product_category").val(res.category);
         $("#product_description").val(res.description);
         $("#product_available").val(res.available);
         $("#product_price").val(res.price);
-        $("#product_rating").val(res.rating.toFixed(2));
+        $("#product_rating").val(product_rating);
         $("#product_num_rating").val(res.no_of_users_rated);
     }
 
@@ -55,6 +61,18 @@ $(function () {
         }else{
             available = "False"
         }
+        // if (rating != null ){
+        //     product_rating = parseFloat(rating)
+        // }
+        // else{
+        //     product_rating = null
+        // }
+        // if (num_rating != null){
+        //     product_num_rating = parseInt(num_rating)
+        // }
+        // else{
+        //     product_num_rating = null
+        // }
         let data = {
             "name": name,
             "category": category,
@@ -277,7 +295,8 @@ $(function () {
             let firstProduct = "";
             for(let i = 0; i < res.length; i++) {
                 let product = res[i];
-                table +=  `<tr id="row_${i}"><td>${product.id}</td><td>${product.name}</td><td>${product.category}</td><td>${product.description}</td><td>${product.available}</td><td>${product.price}</td><td>${product.rating.toFixed(2)}</td></tr>`;
+                if(product.rating == null) table +=  `<tr id="row_${i}"><td>${product.id}</td><td>${product.name}</td><td>${product.category}</td><td>${product.description}</td><td>${product.available}</td><td>${product.price}</td><td>Not-Applicable</td></tr>`;
+                else table +=  `<tr id="row_${i}"><td>${product.id}</td><td>${product.name}</td><td>${product.category}</td><td>${product.description}</td><td>${product.available}</td><td>${product.price}</td><td>${product.rating.toFixed(2)}</td></tr>`;
                 if (i == 0) {
                     firstProduct = product;
                 }

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -61,18 +61,6 @@ $(function () {
         }else{
             available = "False"
         }
-        // if (rating != null ){
-        //     product_rating = parseFloat(rating)
-        // }
-        // else{
-        //     product_rating = null
-        // }
-        // if (num_rating != null){
-        //     product_num_rating = parseInt(num_rating)
-        // }
-        // else{
-        //     product_num_rating = null
-        // }
         let data = {
             "name": name,
             "category": category,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -89,6 +89,7 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn(b"Product Demo REST API Service", resp.data)
 
+
     def test_get_product_list(self):
         """It should Get a list of Products"""
         self._create_products(5)
@@ -555,7 +556,7 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_price_bad_price(self):
-        """It should return 406 for bad price in update price"""
+        """It should return 406 for no price in update price"""
         # create a product to update
         test_product = ProductFactory()
         response = self.client.post(BASE_URL, json=test_product.serialize())
@@ -569,12 +570,21 @@ class TestYourResourceServer(TestCase):
         new_product["price"] = None
         response = self.client.put(f"{BASE_URL}/{id}/price", json=new_product)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
+    def test_update_bad_price(self):
+        """It should return 400 for invalid price in update price"""
+        # create a product to update
+        test_product = ProductFactory()
+        response = self.client.post(BASE_URL, json=test_product.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        id = response.get_json()["id"]
+        new_product = {}
         new_product["price"] = MAX_PRICE + 1
         response = self.client.put(f"{BASE_URL}/{id}/price", json=new_product)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         new_product["price"] = str(MAX_PRICE)
         response = self.client.put(f"{BASE_URL}/{id}/price", json=new_product)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_description_bad_id(self):
         """It should return 404 for bad id in update description"""
@@ -591,7 +601,7 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_description_bad_price(self):
-        """It should return 406 for bad description in update description"""
+        """It should return 406 for no description in update description"""
         # create a product to update
         test_product = ProductFactory()
         response = self.client.post(BASE_URL, json=test_product.serialize())
@@ -605,12 +615,23 @@ class TestYourResourceServer(TestCase):
         new_product["description"] = None
         response = self.client.put(f"{BASE_URL}/{id}/description", json=new_product)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
+    def test_update_bad_description(self):
+        """It should return 400 for bad description in update description"""
+        # create a product to update
+        test_product = ProductFactory()
+        response = self.client.post(BASE_URL, json=test_product.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        id = int(response.get_json()["id"])
+
+        # update the product description
+        new_product = {}
         new_product["description"] = 1
         response = self.client.put(f"{BASE_URL}/{id}/description", json=new_product)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         new_product["description"] = "a" * (MAX_DESCRIPTION_LENGTH + 1)
         response = self.client.put(f"{BASE_URL}/{id}/description", json=new_product)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_category_bad_id(self):
         """It should return 404 for bad id in update category"""
@@ -628,7 +649,7 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_category_bad_type(self):
-        """It should return 406 for bad category in update category"""
+        """It should return 406 for no category in update category"""
         # create a product to update
         test_product = ProductFactory()
         response = self.client.post(BASE_URL, json=test_product.serialize())
@@ -642,9 +663,19 @@ class TestYourResourceServer(TestCase):
         new_product["category"] = None
         response = self.client.put(f"{BASE_URL}/{id}/category", json=new_product)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+    def test_update_bad_category(self):
+        """It should return 400 for bad category in update category"""
+        # create a product to update
+        test_product = ProductFactory()
+        response = self.client.post(BASE_URL, json=test_product.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        id = int(response.get_json()["id"])
+
+        # update the product category
+        new_product = {}
         new_product["category"] = 1
         response = self.client.put(f"{BASE_URL}/{id}/category", json=new_product)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         new_product["category"] = "a" * (MAX_CATEGORY_LENGTH + 1)
         response = self.client.put(f"{BASE_URL}/{id}/category", json=new_product)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -89,7 +89,6 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn(b"Product Demo REST API Service", resp.data)
 
-
     def test_get_product_list(self):
         """It should Get a list of Products"""
         self._create_products(5)
@@ -663,6 +662,7 @@ class TestYourResourceServer(TestCase):
         new_product["category"] = None
         response = self.client.put(f"{BASE_URL}/{id}/category", json=new_product)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
     def test_update_bad_category(self):
         """It should return 400 for bad category in update category"""
         # create a product to update


### PR DESCRIPTION
- Fixed update by category, description, rating, and price in apidocs. Like update we needed to have     `@api.expect(product_model) `and `@api.marshal_with(product_model)` so the user can enter data. 
- We weren't deserializing data in aforementioned functions. The reason we need that is, currently if I enter
 {
  "price": 20,
  "rating": 19,
  "id": "4034"
} 
in /products/{product_id}/price, I can bypass the rating rule and set the rating of product to 19. The same goes for other functions. 
- By adding deserialize function, there is no need for handling bad data such as "price out of range", because we are handling this in deserialize() function. 
Hopefully the price out of range error should be fixed, but since the error is only in cloud, I can't know for sure until we deploy. 
- Fixed null rating issue caused by toFixed 